### PR TITLE
Export a function rather than execute init.run

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,4 +86,4 @@ Bump.prototype.help = function() {
 */
 
 var init = new Bump();
-module.exports = init.run();
+module.exports = function () { init.run(); };


### PR DESCRIPTION
The original version was calling init.run for every task.  With this implementation, init.run only occurs when the registered task is called.
