### PR TITLE
Corrected build script call

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,4 +86,4 @@ Bump.prototype.help = function() {
 */
 
 var init = new Bump();
-module.exports = function () { return init.run(); };
+module.exports = function (version) { return init.run(version); };


### PR DESCRIPTION
Tested both versions. For the build script call (for example bump('patch')), was the parameter missing
