### PR TITLE
added iosbundle to version increment

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,6 +94,17 @@ function Bump() {
                console.log(chalk.green('New file version: ') + chalk.yellow(xmlVersion));
                return xmlVersion;
             }
+            'ios-CFBundleVersion': val => {
+               console.log(chalk.green('Old CFBundleVersion version: ') + chalk.yellow(val));
+               if (config.singleVersion) {
+                  xmlVersion = config.version;
+               }
+               else {
+                  xmlVersion = semver.inc(val, config.bumpType);
+               }
+               console.log(chalk.green('New CFBundleVersion version: ') + chalk.yellow(xmlVersion));
+               return xmlVersion;
+            }
          }];
 
          if (_.isFunction(config.setAndroidXmlCode)) {


### PR DESCRIPTION
When building an Ionic app, the iOSBundle config attribute gets looked over. This helps keep the versions in line for the iTunes. 👍 

